### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main, develop]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     timeout-minutes: 60


### PR DESCRIPTION
Potential fix for [https://github.com/Mr-Mythical/SvelteKit/security/code-scanning/1](https://github.com/Mr-Mythical/SvelteKit/security/code-scanning/1)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is constrained to least privilege.  
Best fix here: define workflow-level permissions right after the trigger (`on:` block) and before `jobs:` so all jobs inherit it consistently. For this workflow, `contents: read` is the minimal and appropriate setting for checkout and running tests. This preserves existing functionality while preventing unintended token write scopes from defaults.

File to change:
- `.github/workflows/ci.yml`  
Region:
- Insert a new top-level `permissions:` block between lines 8 and 9 (after `on` and before `jobs`).

No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
